### PR TITLE
Don't error out when recreating a symlink in $(bindir)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -34,7 +34,7 @@ CLEANFILES = \
 
 install-exec-hook:
 	$(MKDIR_P) $(DESTDIR)$(bindir)
-	$(LN_S) $(appdir)/com.example.Gtk.JSApplication $(DESTDIR)$(bindir)/$(PACKAGE_TARNAME)
+	ln -sf $(appdir)/com.example.Gtk.JSApplication $(DESTDIR)$(bindir)/$(PACKAGE_TARNAME)
 uninstall-hook:
 	-rm -f $(DESTDIR)$(bindir)/$(PACKAGE_TARNAME)
 


### PR DESCRIPTION
"ln -s" fails if the target file already exists.  however, $(LN_S) can be expanded to "ln" or "cp" for portability reasons, though unlikely on recent platforms:
https://gnu.org/software/autoconf/manual/autoconf.html#AC_005fPROG_005fLN_005fS
how about explicitly using "ln -sf" here?
