### PR TITLE
build: Guard git.mk inclusion for distribution tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -49,4 +49,4 @@ clean-local:
 
 EXTRA_DIST = $(PACKAGE_NAME).spec
 
-include $(top_srcdir)/git.mk
+-include $(top_srcdir)/git.mk

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -30,4 +30,4 @@ else
 EXTRA_DIST += testutil.py $(dogtail_tests)
 endif
 
-include $(top_srcdir)/git.mk
+-include $(top_srcdir)/git.mk


### PR DESCRIPTION
git.mk is not supposed to be listed in EXTRA_DIST:
https://github.com/behdad/git.mk/blob/master/git.mk#L43
Avoid error when the file doesn't exist.

(Note: automake implicitly adds sub-Makefile to EXTRA_DIST if it is included through "include" not "-include".)
