### PR TITLE
Fix meson_post_install.py

### DIFF
--- a/meson/meson_post_install.py
+++ b/meson/meson_post_install.py
@@ -10,7 +10,7 @@ destdir = os.environ.get('DESTDIR', '')
 
 if not destdir:
     print('Compiling gsettings schemas...')
-    subprocess.call(['glib-compile-schemas', schemadir])
+    subprocess.call(['glib-compile-schemas', str(datadir / 'glib-2.0' / 'schemas')])
 
     print('Updating icon cache...')
     subprocess.call(['gtk-update-icon-cache', '-qtf', str(datadir / 'icons' / 'hicolor')])


### PR DESCRIPTION
Previous code used 'schemadir' which was not defined, left over from a previous commit.